### PR TITLE
fix python3 comp. of common_imports

### DIFF
--- a/pyrieef/learning/inverse_optimal_control.py
+++ b/pyrieef/learning/inverse_optimal_control.py
@@ -18,7 +18,11 @@
 #                                        Jim Mainprice on Sunday June 13 2018
 
 from __future__ import print_function
-import common_imports
+import sys
+if sys.version_info >= (3, 0):
+    from .common_imports import *
+else:
+    import common_imports
 from motion.objective import *
 from motion.trajectory import *
 import numpy as np


### PR DESCRIPTION
When using python3 the inverse_optimal_control.py fails in importing common_imports. This should fix the issue. 